### PR TITLE
Update 10.0.17: geth v1.10.2

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.10.2 as geth
+FROM ethereum/client-go:v1.10.3 as geth
 
 FROM node:12.14.1 as build-deps-wizard
 RUN apt-get update && apt-get install -y libusb-1.0-0-dev libudev-dev openssl

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.10.1 as geth
+FROM ethereum/client-go:v1.10.2 as geth
 
 FROM node:12.14.1 as build-deps-wizard
 RUN apt-get update && apt-get install -y libusb-1.0-0-dev libudev-dev openssl

--- a/build/files/supervisord.conf
+++ b/build/files/supervisord.conf
@@ -3,7 +3,7 @@ nodaemon=true
 user=root
 
 [program:geth]
-command=/usr/local/bin/geth --datadir /root/.ethereum/ethchain-geth --http --http.addr 0.0.0.0 --http.corsdomain "*" --http.vhosts "*" --ws --ws.origins "*" --ws.addr 0.0.0.0 --rpc.gascap 0 %(ENV_EXTRA_OPTS)s
+command=/usr/local/bin/geth --datadir /root/.ethereum/ethchain-geth --http --http.addr 0.0.0.0 --http.corsdomain "*" --http.vhosts "*" --ws --ws.origins "*" --ws.addr 0.0.0.0 --rpc.gascap 0 --cache 4096 %(ENV_EXTRA_OPTS)s
 autostart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "ethchain-geth.public.dappnode.eth",
-  "version": "10.0.16",
-  "upstream": "v1.10.1",
+  "version": "10.0.17",
+  "upstream": "v1.10.2",
   "autoupdate": true,
   "title": "Ethereum node (Geth + mainnet)",
   "description": "Ethereum Client - based on Geth",
@@ -9,9 +9,9 @@
   "type": "library",
   "chain": "ethereum",
   "image": {
-    "path": "ethchain-geth.public.dappnode.eth_10.0.16.tar.xz",
-    "hash": "/ipfs/QmaTmNkpDXvfNU9rKFsucNsXouc62oyGK2i3yi12aAg4fS",
-    "size": 29619688,
+    "path": "ethchain-geth.public.dappnode.eth_10.0.17.tar.xz",
+    "hash": "/ipfs/Qmcfz3mbp4xw1GXiqjfvV1ut8ofbt3irYhU9piXVVz8pes",
+    "size": 29650376,
     "restart": "always",
     "ports": [
       "30303:30303",

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethchain-geth.public.dappnode.eth",
-  "version": "10.0.17",
+  "version": "10.0.18",
   "upstream": "v1.10.2",
   "autoupdate": true,
   "title": "Ethereum node (Geth + mainnet)",
@@ -9,9 +9,9 @@
   "type": "library",
   "chain": "ethereum",
   "image": {
-    "path": "ethchain-geth.public.dappnode.eth_10.0.17.tar.xz",
-    "hash": "/ipfs/Qmcfz3mbp4xw1GXiqjfvV1ut8ofbt3irYhU9piXVVz8pes",
-    "size": 29650376,
+    "path": "ethchain-geth.public.dappnode.eth_10.0.18.tar.xz",
+    "hash": "/ipfs/Qme8AQtp3KJ5b1YQyUxigS5ea3F1DJYMU9ZXgrDoChwJd9",
+    "size": 29751704,
     "restart": "always",
     "ports": [
       "30303:30303",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   ethchain-geth.public.dappnode.eth:
-    image: 'ethchain-geth.public.dappnode.eth:10.0.16'
+    image: 'ethchain-geth.public.dappnode.eth:10.0.17'
     build: ./build
     volumes:
       - 'ethchain-geth:/root/.ethereum/ethchain-geth'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   ethchain-geth.public.dappnode.eth:
-    image: 'ethchain-geth.public.dappnode.eth:10.0.17'
+    image: 'ethchain-geth.public.dappnode.eth:10.0.18'
     build: ./build
     volumes:
       - 'ethchain-geth:/root/.ethereum/ethchain-geth'

--- a/releases.json
+++ b/releases.json
@@ -85,5 +85,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Thu, 08 Apr 2021 15:07:47 GMT"
     }
+  },
+  "10.0.18": {
+    "hash": "/ipfs/QmbuwnATQbd9ZoYGcyHo7SjaL9msNX8FqUbjSmGXCZgQwF",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Wed, 05 May 2021 21:39:26 GMT"
+    }
   }
 }

--- a/releases.json
+++ b/releases.json
@@ -78,5 +78,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Sat, 13 Mar 2021 10:00:01 GMT"
     }
+  },
+  "10.0.17": {
+    "hash": "/ipfs/QmP16CgUEiwkk8tzdEPJc8kXufUkxczdM4ytGpn1jdii72",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Thu, 08 Apr 2021 15:07:47 GMT"
+    }
   }
 }


### PR DESCRIPTION
Update 10.0.17: geth v1.10.2

/ipfs/QmP16CgUEiwkk8tzdEPJc8kXufUkxczdM4ytGpn1jdii72

Geth v1.10.2 is a maintenance release, containing bug fixes and a few minor new features.
https://github.com/ethereum/go-ethereum/releases