### PR TITLE
Update 10.0.19: geth v1.10.3: update Avado ssl certificate (nginx)

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "ethchain-geth.public.dappnode.eth",
-  "version": "10.0.18",
-  "upstream": "v1.10.2",
+  "version": "10.0.19",
+  "upstream": "v1.10.3",
   "autoupdate": true,
   "title": "Ethereum node (Geth + mainnet)",
   "description": "Ethereum Client - based on Geth",
@@ -9,9 +9,9 @@
   "type": "library",
   "chain": "ethereum",
   "image": {
-    "path": "ethchain-geth.public.dappnode.eth_10.0.18.tar.xz",
-    "hash": "/ipfs/Qme8AQtp3KJ5b1YQyUxigS5ea3F1DJYMU9ZXgrDoChwJd9",
-    "size": 29751704,
+    "path": "ethchain-geth.public.dappnode.eth_10.0.19.tar.xz",
+    "hash": "/ipfs/QmVBcBWZucptkAZrghSe2uSpwZ5x2JyQEYrcnSHTdtik19",
+    "size": 29752360,
     "restart": "always",
     "ports": [
       "30303:30303",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   ethchain-geth.public.dappnode.eth:
-    image: 'ethchain-geth.public.dappnode.eth:10.0.18'
+    image: 'ethchain-geth.public.dappnode.eth:10.0.19'
     build: ./build
     volumes:
       - 'ethchain-geth:/root/.ethereum/ethchain-geth'

--- a/releases.json
+++ b/releases.json
@@ -92,5 +92,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Wed, 05 May 2021 21:39:26 GMT"
     }
+  },
+  "10.0.19": {
+    "hash": "/ipfs/QmZNiiiNhaFbzJk5yn3w95J5DrC5r4K8Y9RBxByno8rYXa",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Fri, 11 Jun 2021 14:17:40 GMT"
+    }
   }
 }


### PR DESCRIPTION
Manifest hash : /ipfs/QmZNiiiNhaFbzJk5yn3w95J5DrC5r4K8Y9RBxByno8rYXa
http://my.dappnode/#/installer/%2Fipfs%2FQmZNiiiNhaFbzJk5yn3w95J5DrC5r4K8Y9RBxByno8rYXa