### PR TITLE
Update 10.0.20: geth v1.10.4

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.10.3 as geth
+FROM ethereum/client-go:v1.10.4 as geth
 
 FROM node:12.14.1 as build-deps-wizard
 RUN apt-get update && apt-get install -y libusb-1.0-0-dev libudev-dev openssl

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "ethchain-geth.public.dappnode.eth",
-  "version": "10.0.19",
-  "upstream": "v1.10.3",
+  "version": "10.0.20",
+  "upstream": "v1.10.4",
   "autoupdate": true,
   "title": "Ethereum node (Geth + mainnet)",
   "description": "Ethereum Client - based on Geth",
@@ -9,9 +9,9 @@
   "type": "library",
   "chain": "ethereum",
   "image": {
-    "path": "ethchain-geth.public.dappnode.eth_10.0.19.tar.xz",
-    "hash": "/ipfs/QmVBcBWZucptkAZrghSe2uSpwZ5x2JyQEYrcnSHTdtik19",
-    "size": 29752360,
+    "path": "ethchain-geth.public.dappnode.eth_10.0.20.tar.xz",
+    "hash": "/ipfs/QmP5oUz5EGx1TfU6YYmnBVSoxsodzy7uHqPZUdtHSVU1Vm",
+    "size": 29852600,
     "restart": "always",
     "ports": [
       "30303:30303",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   ethchain-geth.public.dappnode.eth:
-    image: 'ethchain-geth.public.dappnode.eth:10.0.19'
+    image: 'ethchain-geth.public.dappnode.eth:10.0.20'
     build: ./build
     volumes:
       - 'ethchain-geth:/root/.ethereum/ethchain-geth'

--- a/releases.json
+++ b/releases.json
@@ -99,5 +99,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Fri, 11 Jun 2021 14:17:40 GMT"
     }
+  },
+  "10.0.20": {
+    "hash": "/ipfs/QmYgTHMDK1TKRcVgVDKopx1yiLb112Q9J9oS94rj3nq5tn",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Fri, 18 Jun 2021 20:16:34 GMT"
+    }
   }
 }


### PR DESCRIPTION
Geth v1.10.4 is a feature release and adds compatibility with the upcoming London hard fork.
Enables snap sync by default

https://github.com/ethereum/go-ethereum/releases/tag/v1.10.4

Manifest hash : /ipfs/QmYgTHMDK1TKRcVgVDKopx1yiLb112Q9J9oS94rj3nq5tn