### PR TITLE
Update 10.0.22: geth v1.10.5

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.10.4 as geth
+FROM ethereum/client-go:v1.10.5 as geth
 
 FROM node:12.14.1 as build-deps-wizard
 RUN apt-get update && apt-get install -y libusb-1.0-0-dev libudev-dev openssl

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "ethchain-geth.public.dappnode.eth",
-  "version": "10.0.21",
-  "upstream": "v1.10.4",
+  "version": "10.0.22",
+  "upstream": "v1.10.5",
   "autoupdate": true,
   "title": "Ethereum node (Geth + mainnet)",
   "description": "Ethereum Client - based on Geth",
@@ -9,9 +9,9 @@
   "type": "library",
   "chain": "ethereum",
   "image": {
-    "path": "ethchain-geth.public.dappnode.eth_10.0.21.tar.xz",
-    "hash": "/ipfs/QmSwK5VUvS6HjGzwjikgZFbcGNeQUL1AeVjvFk9aRSGoQy",
-    "size": 29695164,
+    "path": "ethchain-geth.public.dappnode.eth_10.0.22.tar.xz",
+    "hash": "/ipfs/QmX1LSGGNpaScsLqHp3ASvzcCUd2CAVvJrw9cEcNCN8Ddc",
+    "size": 29694608,
     "restart": "always",
     "ports": [
       "443:443",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   ethchain-geth.public.dappnode.eth:
-    image: 'ethchain-geth.public.dappnode.eth:10.0.21'
+    image: 'ethchain-geth.public.dappnode.eth:10.0.22'
     build: ./build
     volumes:
       - 'ethchain-geth:/root/.ethereum/ethchain-geth'

--- a/releases.json
+++ b/releases.json
@@ -113,5 +113,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Fri, 02 Jul 2021 13:22:38 GMT"
     }
+  },
+  "10.0.22": {
+    "hash": "/ipfs/QmSzcx9CzDuZ5fjfM9edee3tYdcqTTqN2ghVzAQRMoXGE7",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Wed, 14 Jul 2021 13:22:33 GMT"
+    }
   }
 }


### PR DESCRIPTION
https://github.com/ethereum/go-ethereum/releases/tag/v1.10.5

Ready for London Fork

+ fix for clean exit/restart

  Manifest hash : /ipfs/QmSzcx9CzDuZ5fjfM9edee3tYdcqTTqN2ghVzAQRMoXGE7
  http://my.dappnode/#/installer/%2Fipfs%2FQmSzcx9CzDuZ5fjfM9edee3tYdcqTTqN2ghVzAQRMoXGE7