### PR TITLE
Update 10.0.23: geth v1.10.6

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.10.5 as geth
+FROM ethereum/client-go:v1.10.6 as geth
 
 FROM node:12.14.1 as build-deps-wizard
 RUN apt-get update && apt-get install -y libusb-1.0-0-dev libudev-dev openssl

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "ethchain-geth.public.dappnode.eth",
-  "version": "10.0.22",
-  "upstream": "v1.10.5",
+  "version": "10.0.23",
+  "upstream": "v1.10.6",
   "autoupdate": true,
   "title": "Ethereum node (Geth + mainnet)",
   "description": "Ethereum Client - based on Geth",
@@ -9,9 +9,9 @@
   "type": "library",
   "chain": "ethereum",
   "image": {
-    "path": "ethchain-geth.public.dappnode.eth_10.0.22.tar.xz",
-    "hash": "/ipfs/QmX1LSGGNpaScsLqHp3ASvzcCUd2CAVvJrw9cEcNCN8Ddc",
-    "size": 29694608,
+    "path": "ethchain-geth.public.dappnode.eth_10.0.23.tar.xz",
+    "hash": "/ipfs/QmSwqUCDmJLmre13G2riaeW4rGju8ViWuigQKb2kGCDv5L",
+    "size": 29790712,
     "restart": "always",
     "ports": [
       "443:443",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   ethchain-geth.public.dappnode.eth:
-    image: 'ethchain-geth.public.dappnode.eth:10.0.22'
+    image: 'ethchain-geth.public.dappnode.eth:10.0.23'
     build: ./build
     volumes:
       - 'ethchain-geth:/root/.ethereum/ethchain-geth'

--- a/releases.json
+++ b/releases.json
@@ -120,5 +120,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Wed, 14 Jul 2021 13:22:33 GMT"
     }
+  },
+  "10.0.23": {
+    "hash": "/ipfs/QmavVWt2rcXY8Vp2em9Y5V7NDh2aJB7GrEnCM1f1cMDfm1",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Thu, 22 Jul 2021 18:04:35 GMT"
+    }
   }
 }


### PR DESCRIPTION
Geth 1.10.6
https://github.com/ethereum/go-ethereum/releases/tag/v1.10.6

Geth v1.10.6 is a hotfix release. This resolves a consensus failure on the Ropsten testnet.

Manifest hash : /ipfs/QmavVWt2rcXY8Vp2em9Y5V7NDh2aJB7GrEnCM1f1cMDfm1
http://my.dappnode/#/installer/%2Fipfs%2FQmavVWt2rcXY8Vp2em9Y5V7NDh2aJB7GrEnCM1f1cMDfm1