### PR TITLE
Update 10.0.24: geth v1.10.7

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.10.7 as geth
+FROM ethereum/client-go:v1.10.8 as geth
 
 FROM node:12.14.1 as build-deps-wizard
 RUN apt-get update && apt-get install -y libusb-1.0-0-dev libudev-dev openssl

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.10.6 as geth
+FROM ethereum/client-go:v1.10.7 as geth
 
 FROM node:12.14.1 as build-deps-wizard
 RUN apt-get update && apt-get install -y libusb-1.0-0-dev libudev-dev openssl

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "ethchain-geth.public.dappnode.eth",
-  "version": "10.0.24",
-  "upstream": "v1.10.7",
+  "version": "10.0.25",
+  "upstream": "v1.10.8",
   "autoupdate": true,
   "title": "Ethereum node (Geth + mainnet)",
   "description": "Ethereum Client - based on Geth",
@@ -9,9 +9,9 @@
   "type": "library",
   "chain": "ethereum",
   "image": {
-    "path": "ethchain-geth.public.dappnode.eth_10.0.24.tar.xz",
-    "hash": "/ipfs/QmWVo15EtLfx8hHz8qk6PYxCs91dSsaEjXP2KTvUZ7GQF9",
-    "size": 29733780,
+    "path": "ethchain-geth.public.dappnode.eth_10.0.25.tar.xz",
+    "hash": "/ipfs/QmQNcQmwcRRaz5xffghxfMJJ9fXWw3SK8xxbH9j61otJo9",
+    "size": 30746484,
     "restart": "always",
     "ports": [
       "443:443",

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "ethchain-geth.public.dappnode.eth",
-  "version": "10.0.23",
-  "upstream": "v1.10.6",
+  "version": "10.0.24",
+  "upstream": "v1.10.7",
   "autoupdate": true,
   "title": "Ethereum node (Geth + mainnet)",
   "description": "Ethereum Client - based on Geth",
@@ -9,9 +9,9 @@
   "type": "library",
   "chain": "ethereum",
   "image": {
-    "path": "ethchain-geth.public.dappnode.eth_10.0.23.tar.xz",
-    "hash": "/ipfs/QmS4xPzcQ8XJmCvQD8RQwwjB6mrgoJLcY2rvMhtFejLVom",
-    "size": 30357180,
+    "path": "ethchain-geth.public.dappnode.eth_10.0.24.tar.xz",
+    "hash": "/ipfs/QmWVo15EtLfx8hHz8qk6PYxCs91dSsaEjXP2KTvUZ7GQF9",
+    "size": 29733780,
     "restart": "always",
     "ports": [
       "443:443",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   ethchain-geth.public.dappnode.eth:
-    image: 'ethchain-geth.public.dappnode.eth:10.0.23'
+    image: 'ethchain-geth.public.dappnode.eth:10.0.24'
     build: ./build
     volumes:
       - 'ethchain-geth:/root/.ethereum/ethchain-geth'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   ethchain-geth.public.dappnode.eth:
-    image: 'ethchain-geth.public.dappnode.eth:10.0.24'
+    image: 'ethchain-geth.public.dappnode.eth:10.0.25'
     build: ./build
     volumes:
       - 'ethchain-geth:/root/.ethereum/ethchain-geth'

--- a/releases.json
+++ b/releases.json
@@ -127,5 +127,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Thu, 22 Jul 2021 18:10:04 GMT"
     }
+  },
+  "10.0.24": {
+    "hash": "/ipfs/QmdXM95ohgjyuMEZAMASxKBdhXKSrPorj8p4YW2jbbCBeX",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Thu, 12 Aug 2021 12:31:41 GMT"
+    }
   }
 }

--- a/releases.json
+++ b/releases.json
@@ -134,5 +134,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Thu, 12 Aug 2021 12:31:41 GMT"
     }
+  },
+  "10.0.25": {
+    "hash": "/ipfs/QmW43jbyqMHnAzZStck4WBR7zC1qYErdETjDHsrXN4ddyn",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Tue, 24 Aug 2021 07:31:28 GMT"
+    }
   }
 }


### PR DESCRIPTION
Geth: https://github.com/ethereum/go-ethereum/releases/tag/v1.10.8

Geth v1.10.8 is a pre-announced hotfix release to patch a vulnerability in the EVM (CVE-2021-39137).

Manifest hash : /ipfs/QmW43jbyqMHnAzZStck4WBR7zC1qYErdETjDHsrXN4ddyn

