### PR TITLE
Update 10.0.26: geth v1.10.9

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.10.8 as geth
+FROM ethereum/client-go:v1.10.9 as geth
 
 FROM node:12.14.1 as build-deps-wizard
 RUN apt-get update && apt-get install -y libusb-1.0-0-dev libudev-dev openssl

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "ethchain-geth.public.dappnode.eth",
-  "version": "10.0.25",
-  "upstream": "v1.10.8",
+  "version": "10.0.26",
+  "upstream": "v1.10.9",
   "autoupdate": true,
   "title": "Ethereum node (Geth + mainnet)",
   "description": "Ethereum Client - based on Geth",
@@ -9,9 +9,9 @@
   "type": "library",
   "chain": "ethereum",
   "image": {
-    "path": "ethchain-geth.public.dappnode.eth_10.0.25.tar.xz",
-    "hash": "/ipfs/QmYDgrvjv4Q2KQFp1GGErjQ5FmLsqjcpA4PdxmvnWafpUZ",
-    "size": 31396692,
+    "path": "ethchain-geth.public.dappnode.eth_10.0.26.tar.xz",
+    "hash": "/ipfs/QmfE5SjTpULH3WCK53z8xBjS25irCsKgKmraxEvJoCx6h2",
+    "size": 31078300,
     "restart": "always",
     "ports": [
       "443:443",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   ethchain-geth.public.dappnode.eth:
-    image: 'ethchain-geth.public.dappnode.eth:10.0.25'
+    image: 'ethchain-geth.public.dappnode.eth:10.0.26'
     build: ./build
     volumes:
       - 'ethchain-geth:/root/.ethereum/ethchain-geth'

--- a/releases.json
+++ b/releases.json
@@ -141,5 +141,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Tue, 24 Aug 2021 07:34:31 GMT"
     }
+  },
+  "10.0.26": {
+    "hash": "/ipfs/QmPbqC4mrCySbNQsWLJkfVHm2dLZW7L6m3vLPke2oWTubU",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Wed, 29 Sep 2021 20:31:59 GMT"
+    }
   }
 }


### PR DESCRIPTION
Geth v1.10.9 is a maintenance release containing mostly bug fixes.

https://github.com/ethereum/go-ethereum/releases/tag/v1.10.9

Manifest hash : /ipfs/QmPbqC4mrCySbNQsWLJkfVHm2dLZW7L6m3vLPke2oWTubU
http://my.dappnode/#/installer/%2Fipfs%2FQmPbqC4mrCySbNQsWLJkfVHm2dLZW7L6m3vLPke2oWTubU