### PR TITLE
Update 10.0.29: geth v1.10.11 

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "ethchain-geth.public.dappnode.eth",
-  "version": "10.0.28",
-  "upstream": "v1.10.10",
+  "version": "10.0.29",
+  "upstream": "v1.10.11",
   "autoupdate": true,
   "title": "Ethereum node (Geth + mainnet)",
   "description": "Ethereum Client - based on Geth",
@@ -9,8 +9,8 @@
   "type": "library",
   "chain": "ethereum",
   "image": {
-    "path": "ethchain-geth.public.dappnode.eth_10.0.28.tar.xz",
-    "hash": "/ipfs/QmV2KJm88S23eB2Pp4EYUuD1WVZHKuvw2feDttjQeMmvkq",
+    "path": "ethchain-geth.public.dappnode.eth_10.0.29.tar.xz",
+    "hash": "/ipfs/QmddsDpnhjEnd8SzxctAfUBgTQBYYo1gH8MYtV2ghj6W3U",
     "size": 30395348,
     "restart": "always",
     "ports": [
@@ -31,5 +31,5 @@
     "RPC endpoint": "http://my.ethchain-geth.public.dappnode.eth:8545",
     "RPC endpoint (SSL)": "https://my.ethchain-geth.public.dappnode.eth"
   },
-  "builddate": "2021-10-20T13:33:19.114Z"
+  "builddate": "2021-10-20T13:44:40.475Z"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   ethchain-geth.public.dappnode.eth:
-    image: 'ethchain-geth.public.dappnode.eth:10.0.28'
+    image: 'ethchain-geth.public.dappnode.eth:10.0.29'
     build: ./build
     volumes:
       - 'ethchain-geth:/root/.ethereum/ethchain-geth'

--- a/releases.json
+++ b/releases.json
@@ -162,5 +162,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Wed, 20 Oct 2021 13:33:19 GMT"
     }
+  },
+  "10.0.29": {
+    "hash": "/ipfs/QmfTR86SLd77QA3DnyhkQka6zeDXB1upwKzeySXBEiJ8GT",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Wed, 20 Oct 2021 13:44:40 GMT"
+    }
   }
 }


### PR DESCRIPTION
Update 10.0.29: geth v1.10.11
    
    https://github.com/ethereum/go-ethereum/releases/tag/v1.10.11
    
    Manifest hash: /ipfs/QmfTR86SLd77QA3DnyhkQka6zeDXB1upwKzeySXBEiJ8GT