### PR TITLE
Update 10.0.40: geth v1.10.19

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.10.17 as geth
+FROM ethereum/client-go:v1.10.19 as geth
 
 FROM node:12.14.1 as build-deps-wizard
 RUN apt-get update && apt-get install -y libusb-1.0-0-dev libudev-dev openssl

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "ethchain-geth.public.dappnode.eth",
-  "version": "10.0.38",
-  "upstream": "v1.10.17",
+  "version": "10.0.40",
+  "upstream": "v1.10.19",
   "autoupdate": true,
   "title": "Ethereum node (Geth + mainnet)",
   "description": "Ethereum Client - based on Geth",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   ethchain-geth.public.dappnode.eth:
-    image: 'ethchain-geth.public.dappnode.eth:10.0.38'
+    image: 'ethchain-geth.public.dappnode.eth:10.0.40'
     build: ./build
     volumes:
       - 'ethchain-geth:/root/.ethereum/ethchain-geth'

--- a/releases.json
+++ b/releases.json
@@ -19,5 +19,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Wed, 30 Mar 2022 08:33:35 GMT"
     }
+  },
+  "10.0.40": {
+    "hash": "/ipfs/QmaTRVs6x4735cDDHy3XGZt5HN6ukgjV4LsXtiRirbvikN",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Wed, 15 Jun 2022 14:10:47 GMT"
+    }
   }
 }


### PR DESCRIPTION
https://github.com/ethereum/go-ethereum/releases/tag/v1.10.19

Manifest hash: /ipfs/QmaTRVs6x4735cDDHy3XGZt5HN6ukgjV4LsXtiRirbvikN