### PR TITLE
feat: bump to 1.15.0

### DIFF
--- a/build/dappnode_package-mainnet.json
+++ b/build/dappnode_package-mainnet.json
@@ -1,7 +1,7 @@
 {
   "name": "ethchain-geth.public.dappnode.eth",
-  "version": "10.0.69",
-  "upstream": "v1.14.13",
+  "version": "10.0.70",
+  "upstream": "v1.15.0",
   "autoupdate": true,
   "title": "Ethereum node (Geth + mainnet)",
   "description": "Ethereum Client - based on Geth",

--- a/build/dappnode_package-mainnet.json
+++ b/build/dappnode_package-mainnet.json
@@ -1,7 +1,7 @@
 {
   "name": "ethchain-geth.public.dappnode.eth",
-  "version": "10.0.73",
-  "upstream": "v1.15.8",
+  "version": "10.0.74",
+  "upstream": "v1.15.9",
   "autoupdate": true,
   "title": "Ethereum node (Geth + mainnet)",
   "description": "Ethereum Client - based on Geth",

--- a/build/dappnode_package-mainnet.json
+++ b/build/dappnode_package-mainnet.json
@@ -1,7 +1,7 @@
 {
   "name": "ethchain-geth.public.dappnode.eth",
-  "version": "10.0.72",
-  "upstream": "v1.15.4",
+  "version": "10.0.73",
+  "upstream": "v1.15.8",
   "autoupdate": true,
   "title": "Ethereum node (Geth + mainnet)",
   "description": "Ethereum Client - based on Geth",
@@ -10,13 +10,8 @@
   "chain": "ethereum",
   "image": {
     "restart": "always",
-    "ports": [
-      "30303:30303",
-      "30303:30303/udp"
-    ],
-    "volumes": [
-      "ethchain-geth:/root/.ethereum/ethchain-geth"
-    ],
+    "ports": ["30303:30303", "30303:30303/udp"],
+    "volumes": ["ethchain-geth:/root/.ethereum/ethchain-geth"],
     "environment": [
       "NETWORK=mainnet",
       "EXTRA_OPTS=--http.api eth,net,web3,txpool"

--- a/build/dappnode_package-mainnet.json
+++ b/build/dappnode_package-mainnet.json
@@ -1,7 +1,7 @@
 {
   "name": "ethchain-geth.public.dappnode.eth",
-  "version": "10.0.71",
-  "upstream": "v1.15.2",
+  "version": "10.0.72",
+  "upstream": "v1.15.4",
   "autoupdate": true,
   "title": "Ethereum node (Geth + mainnet)",
   "description": "Ethereum Client - based on Geth",
@@ -10,8 +10,13 @@
   "chain": "ethereum",
   "image": {
     "restart": "always",
-    "ports": ["30303:30303", "30303:30303/udp"],
-    "volumes": ["ethchain-geth:/root/.ethereum/ethchain-geth"],
+    "ports": [
+      "30303:30303",
+      "30303:30303/udp"
+    ],
+    "volumes": [
+      "ethchain-geth:/root/.ethereum/ethchain-geth"
+    ],
     "environment": [
       "NETWORK=mainnet",
       "EXTRA_OPTS=--http.api eth,net,web3,txpool"

--- a/build/dappnode_package-mainnet.json
+++ b/build/dappnode_package-mainnet.json
@@ -1,7 +1,7 @@
 {
   "name": "ethchain-geth.public.dappnode.eth",
-  "version": "10.0.74",
-  "upstream": "v1.15.9",
+  "version": "10.0.75",
+  "upstream": "v1.15.10",
   "autoupdate": true,
   "title": "Ethereum node (Geth + mainnet)",
   "description": "Ethereum Client - based on Geth",

--- a/build/dappnode_package-mainnet.json
+++ b/build/dappnode_package-mainnet.json
@@ -1,7 +1,7 @@
 {
   "name": "ethchain-geth.public.dappnode.eth",
-  "version": "10.0.70",
-  "upstream": "v1.15.0",
+  "version": "10.0.71",
+  "upstream": "v1.15.2",
   "autoupdate": true,
   "title": "Ethereum node (Geth + mainnet)",
   "description": "Ethereum Client - based on Geth",
@@ -10,13 +10,8 @@
   "chain": "ethereum",
   "image": {
     "restart": "always",
-    "ports": [
-      "30303:30303",
-      "30303:30303/udp"
-    ],
-    "volumes": [
-      "ethchain-geth:/root/.ethereum/ethchain-geth"
-    ],
+    "ports": ["30303:30303", "30303:30303/udp"],
+    "volumes": ["ethchain-geth:/root/.ethereum/ethchain-geth"],
     "environment": [
       "NETWORK=mainnet",
       "EXTRA_OPTS=--http.api eth,net,web3,txpool"

--- a/build/docker-compose-mainnet.yml
+++ b/build/docker-compose-mainnet.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   ethchain-geth.public.dappnode.eth:
-    image: 'ethchain-geth.public.dappnode.eth:10.0.74'
+    image: 'ethchain-geth.public.dappnode.eth:10.0.75'
     build:
       context: ./build
       args:
-        VERSION: v1.15.9
+        VERSION: v1.15.10
     volumes:
       - 'ethchain-geth:/root/.ethereum/ethchain-geth'
     ports:

--- a/build/docker-compose-mainnet.yml
+++ b/build/docker-compose-mainnet.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   ethchain-geth.public.dappnode.eth:
-    image: 'ethchain-geth.public.dappnode.eth:10.0.72'
+    image: 'ethchain-geth.public.dappnode.eth:10.0.73'
     build:
       context: ./build
       args:
-        VERSION: v1.15.4
+        VERSION: v1.15.8
     volumes:
       - 'ethchain-geth:/root/.ethereum/ethchain-geth'
     ports:

--- a/build/docker-compose-mainnet.yml
+++ b/build/docker-compose-mainnet.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   ethchain-geth.public.dappnode.eth:
-    image: 'ethchain-geth.public.dappnode.eth:10.0.69'
+    image: 'ethchain-geth.public.dappnode.eth:10.0.70'
     build:
       context: ./build
       args:
-        VERSION: v1.14.13
+        VERSION: v1.15.0
     volumes:
       - 'ethchain-geth:/root/.ethereum/ethchain-geth'
     ports:

--- a/build/docker-compose-mainnet.yml
+++ b/build/docker-compose-mainnet.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   ethchain-geth.public.dappnode.eth:
-    image: 'ethchain-geth.public.dappnode.eth:10.0.73'
+    image: 'ethchain-geth.public.dappnode.eth:10.0.74'
     build:
       context: ./build
       args:
-        VERSION: v1.15.8
+        VERSION: v1.15.9
     volumes:
       - 'ethchain-geth:/root/.ethereum/ethchain-geth'
     ports:

--- a/build/docker-compose-mainnet.yml
+++ b/build/docker-compose-mainnet.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   ethchain-geth.public.dappnode.eth:
-    image: 'ethchain-geth.public.dappnode.eth:10.0.70'
+    image: 'ethchain-geth.public.dappnode.eth:10.0.71'
     build:
       context: ./build
       args:
-        VERSION: v1.15.0
+        VERSION: v1.15.2
     volumes:
       - 'ethchain-geth:/root/.ethereum/ethchain-geth'
     ports:

--- a/build/docker-compose-mainnet.yml
+++ b/build/docker-compose-mainnet.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   ethchain-geth.public.dappnode.eth:
-    image: 'ethchain-geth.public.dappnode.eth:10.0.71'
+    image: 'ethchain-geth.public.dappnode.eth:10.0.72'
     build:
       context: ./build
       args:
-        VERSION: v1.15.2
+        VERSION: v1.15.4
     volumes:
       - 'ethchain-geth:/root/.ethereum/ethchain-geth'
     ports:


### PR DESCRIPTION
- do not downgrade to 1.14.x as it requires a chain resync. -tested on test machine, works.