### PR TITLE
chore: update Geth from v1.17.3 to v1.17.4

### DIFF
--- a/build/dappnode_package-mainnet.json
+++ b/build/dappnode_package-mainnet.json
@@ -1,7 +1,7 @@
 {
   "name": "ethchain-geth.public.dappnode.eth",
-  "version": "10.0.81",
-  "upstream": "v1.17.3",
+  "version": "10.0.82",
+  "upstream": "v1.17.4",
   "autoupdate": true,
   "title": "Ethereum node (Geth + mainnet)",
   "description": "Ethereum Client - based on Geth",

--- a/build/docker-compose-mainnet.yml
+++ b/build/docker-compose-mainnet.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   ethchain-geth.public.dappnode.eth:
-    image: 'ethchain-geth.public.dappnode.eth:10.0.81'
+    image: 'ethchain-geth.public.dappnode.eth:10.0.82'
     build:
       context: ./build
       args:
-        VERSION: v1.17.3
+        VERSION: v1.17.4
     volumes:
       - 'ethchain-geth:/root/.ethereum/ethchain-geth'
     ports:


### PR DESCRIPTION
## Automated Geth Upstream Update

This PR updates the Geth upstream version from
**v1.17.3** to
**v1.17.4**.

### Changes made:

- Updated `upstream` version in `dappnode_package-mainnet.json`
- Incremented `version` (patch level) in
  `dappnode_package-mainnet.json`
- Updated `image` tag in `docker-compose-mainnet.yml`
- Updated `VERSION` build argument in
  `docker-compose-mainnet.yml`

### Package version changes:

- Package version:
  **10.0.81** →
  **10.0.82**
- Geth version: **v1.17.3** →
  **v1.17.4**

---
cc @flisko

*This PR was created automatically by the
[update-upstream workflow](.github/workflows/update_upstream.yml).*

Please review and merge if the changes look correct.